### PR TITLE
Add development fixes into orionx

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,21 @@ You can use the variables in the template, as long as the json configuration for
 You can create views, routes, models and more in the default configuration or change it and add more templates.
 
 ```bash
+orion generate [entity] [name] [param]
+```
+
+Example:
+
+```bash
 orion generate view
 orion generate routes
+```
+
+Advanced usage:
+
+```bash
+orion generate view name-of-view
+orion generate routes category /category/:id
 ```
 
 ### Change profiles

--- a/main.js
+++ b/main.js
@@ -35,6 +35,14 @@ exports.execute = function () {
       position: 1,
       help: 'Name of templates to generate, see settings.json'
     })
+    .option('entity_name', {
+      position: 2,
+      help: 'Name of entity to generate without prompt'
+    })
+    .option('entity_param', {
+      position: 3,
+      help: 'Additional parameter for entity generation'
+    })
     .callback(require('./commands/generate'))
     .help('Scaffolds templates (execute from within the app)')
   ;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orion-cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Console scaffolding and development tool for Meteor Projects",
   "main": "notExistant.js",
   "scripts": {


### PR DESCRIPTION
Change version in package.json. This fix #13, closes #17 and resolve matteodem/meteor-boilerplate#8

Fix #18 — ability to add an arguments to the generator 

```
orion generate [entity] [name] [param]
```

Example:

```
orion generate view cat

orion generate routes cat /cat/:id
```

Added examples of usage in README.md
